### PR TITLE
added support for external mongo db. on windows, run the meteor_run.bat file and pass in the mongodb pwd

### DIFF
--- a/imports/ui/pages/NotFound.jsx
+++ b/imports/ui/pages/NotFound.jsx
@@ -1,0 +1,17 @@
+//403 page tbd
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+
+export default class NotFound extends Component {
+
+	render() {
+		// Just render a placeholder container that will be filled in
+		return(
+			<div className="container">
+				<header>
+					<h1>404</h1>
+				</header>
+			</div>
+			);
+	}
+}

--- a/infrastructure/scripts/meteor_run.bat
+++ b/infrastructure/scripts/meteor_run.bat
@@ -1,0 +1,15 @@
+@echo off
+if "%~1"=="" (
+    echo Pleas provide a mongodb password.
+    goto end
+) 
+
+echo Running meteor with external mongo db...
+
+set pwd=%1
+shift
+set MONGO_URL=mongodb://admin:%pwd%@159.65.225.215:27017/foodDB
+
+meteor
+
+:end

--- a/infrastructure/scripts/mongo_server_setup.sh
+++ b/infrastructure/scripts/mongo_server_setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+MONGO_PWD=$1
+#add mongo repo
+cat > /etc/yum.repos.d/mongodb-org.repo << 'endmsg'
+[mongodb-org-3.4]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
+
+endmsg
+
+yum repolist | grep 'mongodb'
+
+yum install -y mongodb-org
+
+systemctl enable mongod
+systemctl start mongod
+systemctl status mongod
+
+#Check logs to see if waiting for connections
+tail /var/log/mongodb/mongod.log | tail -1
+
+# make a copy of the orig mongod.conf
+cp /etc/mongod.conf /etc/mongod.conf.old
+
+# Enable mongo auth
+echo "
+security:
+   authorization: \"enabled\"" | tee -a /etc/mongod.conf
+
+# Enable mongo for all interfaces
+sed -i 's/.*bind/#  bind/' /etc/mongod.conf
+
+# add the mongo admin user
+mongo_statement="db.createUser({user:'admin', pwd:'${MONGO_PWD}',roles:['readWrite','dbAdmin']})"
+mongo foodDB --eval "${mongo_statement}"
+
+# refresh config from mongod.conf file
+systemctl restart mongod
+
+#selinux changes
+#semanage port -a -t mongod_port_t -p tcp 27017
+echo "Installation is complete, please test that you can connect to mongo by runnning the following:"
+echo "mongo -u admin -p ${MONGOPWD} --authenticationDatabase foodDB --host 159.65.225.215:27017"


### PR DESCRIPTION
to run meteor and attach to the new public mongo, simply run meteor_run.bat <password>, where password is the password to the mongo db (message me for it)